### PR TITLE
Feature/TERA-1404 upgrade dropwizard web security bundle to the latest version of dropwizard

### DIFF
--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -1,0 +1,34 @@
+##
+# Created by brightSPARK Labs
+# www.brightsparklabs.com
+##
+
+name: Dependabot-Reviewer
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  review-dependabot-pr:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    steps:
+      # Fetch metadata for dependabot PR updated dependencies
+      - name: Fetch Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1.3.5
+      # Enable auto-merge for dependabot PR
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      # Approve dependabot PR for patch and minor updates
+      - name: Approve patch and minor updates
+        if: ${{steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor'}}
+        run: gh pr review $PR_URL --approve -b "I'm **approving** this pull request because **it includes a patch or minor update**"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+##
+# Created by brightSPARK Labs
+# www.brightsparklabs.com
+##
+
+name: Publish
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  Publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Fix tag
+        # Workaround actions/checkout bug. See:
+        # - https://github.com/actions/checkout/issues/290
+        # - https://github.com/actions/checkout/issues/882
+        if: github.ref_type == 'tag'
+        run: git fetch -fv origin tag "${GITHUB_REF_NAME}"
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: "gradle"
+      - name: Publish package
+        run: |
+          mkdir -p ~/.gradle
+          ./gradlew -i publishToMavenCentral
+        env:
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,30 @@
+##
+# Created by brightSPARK Labs
+# www.brightsparklabs.com
+##
+
+name: Unit-Tests
+on: [push]
+
+jobs:
+  Unit-Tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Fetch all commits to ensure `git describe` returns correct version.
+          fetch-depth: 0
+      - name: Fix tag
+        # Workaround actions/checkout bug. See:
+        # - https://github.com/actions/checkout/issues/290
+        # - https://github.com/actions/checkout/issues/882
+        if: github.ref_type == 'tag'
+        run: git fetch -fv origin tag "${GITHUB_REF_NAME}"
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: "temurin"
+          cache: "gradle"
+      - name: Test with Gradle
+        run: ./gradlew build

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 dropwizard-web-security
 =======================
-[![Circle CI](https://circleci.com/gh/palantir/dropwizard-web-security.svg?style=shield&circle-token=52b148126fda6cfba213cb832ff733d04d0d7277)](https://circleci.com/gh/palantir/dropwizard-web-security)
-[![Download](https://api.bintray.com/packages/palantir/releases/dropwizard-web-security/images/download.svg) ](https://bintray.com/palantir/releases/dropwizard-web-security/_latestVersion)
-
+[![Build Status](https://github.com/brightsparklabs/dropwizard-web-security/actions/workflows/unit_tests.yml/badge.svg)](https://github.com/brightsparklabs/dropwizard-web-security/actions/workflows/unit_tests.yml)
+[![Maven](https://img.shields.io/maven-central/v/com.brightsparklabs/dropwizard-web-security)](https://search.maven.org/artifact/com.brightsparklabs/dropwizard-web-security)
 **THIS IS A FORK OF THE UNMAINTAINED
 [dropwizard-web-security](https://github.com/palantir/dropwizard-web-security).**
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ dropwizard-web-security
 =======================
 [![Build Status](https://github.com/brightsparklabs/dropwizard-web-security/actions/workflows/unit_tests.yml/badge.svg)](https://github.com/brightsparklabs/dropwizard-web-security/actions/workflows/unit_tests.yml)
 [![Maven](https://img.shields.io/maven-central/v/com.brightsparklabs/dropwizard-web-security)](https://search.maven.org/artifact/com.brightsparklabs/dropwizard-web-security)
+
+
 **THIS IS A FORK OF THE UNMAINTAINED
 [dropwizard-web-security](https://github.com/palantir/dropwizard-web-security).**
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,13 @@ plugins {
     id 'com.brightsparklabs.gradle.baseline' version "4.4.0"
 
     id 'java'
+
+    id 'maven-publish'
+    // Maven Central requires artifacts to be signed.
+    id 'signing'
+
+    // Maven Central publishing needs to be fed through Nexus.
+    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 }
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,12 @@ plugins {
     id 'com.brightsparklabs.gradle.baseline' version "4.4.0"
 
     id 'java'
-
     id 'maven-publish'
+
+    // -----------------------------------------------------------------------------
+    // PUBLISHING
+    // -----------------------------------------------------------------------------
+
     // Maven Central requires artifacts to be signed.
     id 'signing'
 
@@ -86,4 +90,88 @@ dependencies {
     annotationProcessor(
             "org.immutables:value:${versions.immutables}",
             )
+}
+
+// -----------------------------------------------------------------------------
+// SETUP ARTIFACTS FOR PUBLISHING
+// -----------------------------------------------------------------------------
+
+// Maven Central requires javadoc and sources.
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            groupId project.group
+            artifactId project.name
+            version project.version
+            from components.java
+
+            // Maven Central requires specific POM attributes.
+            pom {
+                name = project.name
+                description = project.description
+                url = project.url
+
+                scm {
+                    connection = project.scm
+                    developerConnection = project.scm
+                    url = project.scm
+                }
+
+                licenses {
+                    license {
+                        name = 'MIT License'
+                        url = 'http://www.opensource.org/licenses/mit-license.php'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'brightsparklabs'
+                        name = 'brightSPARK Labs'
+                        email = 'enquire@brightsparklabs.com'
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Maven Central requires signed artifacts.
+signing {
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign publishing.publications.mavenJava
+
+    // Only require signing when publishing (otherwise normal builds would need GPG keys).
+    required { gradle.taskGraph.hasTask("publishToSonatype") }
+}
+
+// -----------------------------------------------------------------------------
+// PUBLISH ARTIFACTS (via nexus)
+// -----------------------------------------------------------------------------
+
+nexusPublishing {
+    repositories {
+        // Credentials default to:
+        // - Property `sonatypeUsername` or ENV variable `ORG_GRADLE_PROJECT_sonatypeUsername`.
+        // - Property `sonatypePassword` or ENV variable ORG_GRADLE_PROJECT_sonatypePassword`.
+        sonatype()
+    }
+}
+
+task prePublishToMavenCentral {
+    group 'brightSPARK Labs - Maven Central Publishing'
+    description 'Stages the release on Sonatype ready for publishing to Maven Central.'
+    dependsOn 'publishToSonatype', 'closeSonatypeStagingRepository'
+}
+task publishToMavenCentral {
+    group 'brightSPARK Labs - Maven Central Publishing'
+    description 'Publishes the release to Maven Central.'
+    dependsOn 'publishToSonatype', 'closeAndReleaseSonatypeStagingRepository'
 }


### PR DESCRIPTION
As discussed with @al-jeyapal, the publishToMaven job has not been tested, as the required credentials are only available in this repo, and not the forked repo I first tested. Since this job is derived from the datastore repo I'm assuming it will work this time.